### PR TITLE
Split Fund name string to further fields

### DIFF
--- a/welcome.ui
+++ b/welcome.ui
@@ -263,7 +263,7 @@ font: 350 10pt &quot;Fira Sans&quot;;</string>
      <string notr="true">color: rgb(90, 110, 200);</string>
     </property>
     <property name="text">
-     <string>- Sudheer Tammini - v1.2</string>
+     <string>- rtshiva V1.3 </string>
     </property>
    </widget>
   </widget>


### PR DESCRIPTION
Fund Name field was containing ISIN, Advisor & Registrar in the earlier commit. This patch has modified the output to show Fund Name separate from ISIN, Advisor & Registrar in their own columns. 

Also fixed the regex parsing to ensure that whenever fund name goes to next line it is also considered and included in the final output generated.